### PR TITLE
Set MSACCrashes userConfirmationHandler as documented by Microsoft

### DIFF
--- a/AppBox/AppDelegate.m
+++ b/AppBox/AppDelegate.m
@@ -31,9 +31,38 @@
     
     //Init AppCenter
     [[NSUserDefaults standardUserDefaults] registerDefaults: @{ @"NSApplicationCrashOnExceptions": @YES }];
+    // Setting userConfirmationHandler as documented on https://docs.microsoft.com/en-us/appcenter/sdk/crashes/macos#ask-for-the-users-consent-to-send-a-crash-log
+    [MSACCrashes setUserConfirmationHandler:^BOOL(NSArray<MSACErrorReport *> * _Nonnull errorReports)
+     {
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"Sorry about that!";
+        alert.informativeText = @"Do you want to send a crash report so we can fix the issue?";
+        
+        [alert addButtonWithTitle:@"Always send"];
+        [alert addButtonWithTitle:@"Send"];
+        [alert addButtonWithTitle:@"Don't send"];
+        alert.alertStyle = NSAlertStyleWarning;
+        
+        switch ([alert runModal])
+        {
+            case NSAlertFirstButtonReturn:
+                [MSACCrashes notifyWithUserConfirmation:MSACUserConfirmationAlways];
+                break;
+            case NSAlertSecondButtonReturn:
+                [MSACCrashes notifyWithUserConfirmation:MSACUserConfirmationSend];
+                break;
+            case NSAlertThirdButtonReturn:
+                [MSACCrashes notifyWithUserConfirmation:MSACUserConfirmationDontSend];
+                break;
+            default:
+                break;
+                
+        }
+        return true; // Return true if the SDK should await user confirmation, otherwise return false.
+    }];
+        
     NSString *appCenter = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"AppCenter"];
     [MSACAppCenter start:appCenter withServices: @[[MSACAnalytics class], [MSACCrashes class]]];
-    [MSACCrashes notifyWithUserConfirmation: MSACUserConfirmationAlways];
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {


### PR DESCRIPTION
Fix AppCenterCrashes usage reported in https://github.com/getappbox/fastlane-plugin-appbox/issues/8 

`2022-05-11 12:53:34.005 AppBox[61554:9392769] [AppCenterCrashes] ERROR: -[MSACCrashes notifyWithUserConfirmation:]/1280 Incorrect usage of notifyWithUserConfirmation: it should only be called from userConfirmationHandler. For more information refer to the documentation.`

